### PR TITLE
Overflow bug with uint32s

### DIFF
--- a/msgpack.coffee
+++ b/msgpack.coffee
@@ -396,8 +396,10 @@ class MsgPack
         return (buf[idx++] << 8) | buf[idx++]
        
     uint32 = (buf) ->
-        return (buf[idx++] << 24) | (buf[idx++] << 16) | (buf[idx++] << 8) | buf[idx++]
-        
+        num = (buf[idx++] << 24) | (buf[idx++] << 16) | (buf[idx++] << 8) | buf[idx++]
+        return num if num >= 0 # no overflow occured
+        return 0xFFFFFFFF + num + 1 # correct the overflow
+
     raw = (buf, len) ->
         iz = idx + len
         out = []

--- a/msgpack.js
+++ b/msgpack.js
@@ -307,7 +307,12 @@
       return (buf[idx++] << 8) | buf[idx++];
     };
     uint32 = function(buf) {
-      return (buf[idx++] << 24) | (buf[idx++] << 16) | (buf[idx++] << 8) | buf[idx++];
+      var num;
+      num = (buf[idx++] << 24) | (buf[idx++] << 16) | (buf[idx++] << 8) | buf[idx++];
+      if (num >= 0) {
+        return num;
+      }
+      return 0xFFFFFFFF + num + 1;
     };
     raw = function(buf, len) {
       var char, fromCharCode, i, iz, out;

--- a/test.js
+++ b/test.js
@@ -1,27 +1,32 @@
-var MsgPack = require('coffeepack'),
+var MsgPack = require('./msgpack'),
     assert = require('assert');
 
 var object = {
 	numbers: [
 		Infinity,
 		-Infinity,
+
 		100, // positive fixnum
 		0xF0, // uint8
 		0xFFF0, //uint16
 		0xFFFFFFF0, // uint32
+		0x1FFFFFFFF, // uint64 with bit 31 on (sign bit for right half)
 		0xFFFFFFFFFFFFFF0, // uint64
+
 		-100, // negative fixnum
 		-0xF0, // int8
 		-0xFFF0, //int16
 		-0xFFFFFFF0, // int32
 		-0xFFFFFFFFFFFFFF0, // int64
+
+		1.0384583e+34, // double with all fraction bits on
 	],
 
-    foo: "bar",
-    person: {
-        firstName: 'Devon',
-        lastName: 'Govett'
-    }
+	foo: "bar",
+	person: {
+		firstName: 'Devon',
+		lastName: 'Govett'
+	}
 }
 
 assert.deepEqual(MsgPack.unpack(MsgPack.pack(object)), object);

--- a/test.js
+++ b/test.js
@@ -2,8 +2,22 @@ var MsgPack = require('coffeepack'),
     assert = require('assert');
 
 var object = {
+	numbers: [
+		Infinity,
+		-Infinity,
+		100, // positive fixnum
+		0xF0, // uint8
+		0xFFF0, //uint16
+		0xFFFFFFF0, // uint32
+		0xFFFFFFFFFFFFFF0, // uint64
+		-100, // negative fixnum
+		-0xF0, // int8
+		-0xFFF0, //int16
+		-0xFFFFFFF0, // int32
+		-0xFFFFFFFFFFFFFF0, // int64
+	],
+
     foo: "bar",
-    baz: [1, 2, 3, Infinity, -Infinity],
     person: {
         firstName: 'Devon',
         lastName: 'Govett'


### PR DESCRIPTION
The `uint32` function was basically decoding signed integers, which gave an incorrect result any time the leftmost bit (the "sign bit") was on. I've corrected this issue, but the `uint32` function is used in many other places than just decoding uint32s and I am not sure if any of them are expecting the incorrect result.
