### PR TITLE
Big numbers

### DIFF
--- a/msgpack.coffee
+++ b/msgpack.coffee
@@ -73,7 +73,7 @@ class MsgPack
                         bytes.push 0xcb, 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
             
                     # integer    
-                    else if Math.floor(val) is val
+                    else if Math.floor(val) is val and -0x8000000000000000 <= val < 0x10000000000000000
                         if val >= 0
                             # positive fixnum
                             if val < 0x80
@@ -92,16 +92,13 @@ class MsgPack
                                 bytes.push 0xce, val >>> 24, (val >> 16) & 0xff, (val >> 8) & 0xff, val & 0xff
                         
                             # uint64
-                            else if val < 0x10000000000000000
+                            else
                                 high = Math.floor(val / 0x100000000)
                                 low  = val & 0xffffffff
                                 bytes.push 0xcf, (high >> 24) & 0xff, (high >> 16) & 0xff,
                                                  (high >>  8) & 0xff,  high        & 0xff,
                                                  (low  >> 24) & 0xff, (low  >> 16) & 0xff,
                                                  (low  >>  8) & 0xff,  low         & 0xff
-                    
-                            else    
-                                throw 'Number too large.'
                     
                         else
                             # negative fixnum
@@ -123,16 +120,13 @@ class MsgPack
                                 bytes.push 0xd2, val >>> 24, (val >> 16) & 0xff, (val >> 8) & 0xff, val & 0xff
                         
                             # int64
-                            else if val >= -0x8000000000000000
+                            else
                                 high = Math.floor(val / 0x100000000)
                                 low  = val & 0xffffffff
                                 bytes.push 0xd3, (high >> 24) & 0xff, (high >> 16) & 0xff,
                                                  (high >>  8) & 0xff,  high        & 0xff,
                                                  (low  >> 24) & 0xff, (low  >> 16) & 0xff,
                                                  (low  >>  8) & 0xff,  low         & 0xff
-                    
-                            else    
-                                throw 'Number too small.'
                 
                     # float
                     else

--- a/msgpack.js
+++ b/msgpack.js
@@ -84,7 +84,7 @@
               bytes.push(0xcb, 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
             } else if (val === -Infinity) {
               bytes.push(0xcb, 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
-            } else if (Math.floor(val) === val) {
+            } else if (Math.floor(val) === val && (-0x8000000000000000 <= val && val < 0x10000000000000000)) {
               if (val >= 0) {
                 if (val < 0x80) {
                   bytes.push(val);
@@ -94,12 +94,10 @@
                   bytes.push(0xcd, val >> 8, val & 0xff);
                 } else if (val < 0x100000000) {
                   bytes.push(0xce, val >>> 24, (val >> 16) & 0xff, (val >> 8) & 0xff, val & 0xff);
-                } else if (val < 0x10000000000000000) {
+                } else {
                   high = Math.floor(val / 0x100000000);
                   low = val & 0xffffffff;
                   bytes.push(0xcf, (high >> 24) & 0xff, (high >> 16) & 0xff, (high >> 8) & 0xff, high & 0xff, (low >> 24) & 0xff, (low >> 16) & 0xff, (low >> 8) & 0xff, low & 0xff);
-                } else {
-                  throw 'Number too large.';
                 }
               } else {
                 if (val >= -32) {
@@ -112,12 +110,10 @@
                 } else if (val >= -0x80000000) {
                   val += 0x100000000;
                   bytes.push(0xd2, val >>> 24, (val >> 16) & 0xff, (val >> 8) & 0xff, val & 0xff);
-                } else if (val >= -0x8000000000000000) {
+                } else {
                   high = Math.floor(val / 0x100000000);
                   low = val & 0xffffffff;
                   bytes.push(0xd3, (high >> 24) & 0xff, (high >> 16) & 0xff, (high >> 8) & 0xff, high & 0xff, (low >> 24) & 0xff, (low >> 16) & 0xff, (low >> 8) & 0xff, low & 0xff);
-                } else {
-                  throw 'Number too small.';
                 }
               }
             } else {


### PR DESCRIPTION
If a number is too big (positive _or_ negative) for a int64 (or uint64), an error would be thrown ("number too big" or "too small"). These big numbers can just be encoded as a double.

PS: Sorry for the pull spam.
